### PR TITLE
Change `git log` format on `release` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.3.0...HEAD)
 
+- Change `git log` format on `release` task [#16](https://github.com/ybiquitous/aufgaben/pull/16)
+
 ## 0.3.0
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.2.0...0.3.0)

--- a/lib/aufgaben/release.rb
+++ b/lib/aufgaben/release.rb
@@ -55,7 +55,7 @@ module Aufgaben
           msg "Releasing a new version: #{current_version} -> #{new_version}"
         end
 
-        sh "git", "--no-pager", "log", "--oneline", "#{current_version}..HEAD"
+        sh "git", "--no-pager", "log", "--pretty='format:%C(auto)%h %Creset%s'", "#{current_version}..HEAD"
 
         if dry_run?
           msg "This is a dry-run mode. No actual changes. Next, run this without `DRY_RUN=1`."


### PR DESCRIPTION
See [Git - git-log Documentation](https://www.git-scm.com/docs/git-log#_pretty_formats).

The `--oneline` option is affected by an user's settings, so this uses the `--pretty` option explicitly.