### PR TITLE
Trim unneeded quotes from `git log` format

### DIFF
--- a/lib/aufgaben/release.rb
+++ b/lib/aufgaben/release.rb
@@ -55,7 +55,7 @@ module Aufgaben
           msg "Releasing a new version: #{current_version} -> #{new_version}"
         end
 
-        sh "git", "--no-pager", "log", "--pretty='format:%C(auto)%h %Creset%s'", "#{current_version}..HEAD"
+        sh "git", "--no-pager", "log", "--format=%C(auto)%h %Creset%s", "#{current_version}..HEAD"
 
         if dry_run?
           msg "This is a dry-run mode. No actual changes. Next, run this without `DRY_RUN=1`."


### PR DESCRIPTION
See the following incorrect example:

> git --no-pager log --pretty='format:%C(auto)%h %Creset%s' 0.3.0..HEAD
> 'format:7c9edbb Change `git log` format on `release` task (#16)'