### PR TITLE
Add `bump:nodejs` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.4.2...HEAD)
 
+- Add `bump:nodejs` task [#22](https://github.com/ybiquitous/aufgaben/pull/22)
+
 ## 0.4.2
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.4.1...0.4.2)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ And then execute:
 $ rake bump:ruby'[2.6.5]' [DRY_RUN=1]
 ```
 
+### Bumping up Node.js
+
+Configure your `Rakefile` as follows:
+
+```ruby
+require "aufgaben/bump/nodejs"
+Aufgaben::Bump::Nodejs.new do |t|
+  t.files << "Dockerfile.production" # defaults to ["Dockerfile"]
+  t.version_files << "nodejs-version.txt" # defaults to [".node-version", ".nvmrc"]
+end
+```
+
+And then execute:
+
+```shell
+$ rake bump:nodejs'[12.16.1]' [DRY_RUN=1]
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/aufgaben/bump/base.rb
+++ b/lib/aufgaben/bump/base.rb
@@ -1,0 +1,105 @@
+require "erb"
+require "set"
+
+require_relative "../base"
+require_relative "../bump"
+
+module Aufgaben
+  module Bump
+    class Base < Aufgaben::Base
+      DEFAULT_COMMIT_MESSAGE_TEMPLATE = <<-'MSG'.freeze
+Bump <%= target_name %> from <%= current_version %> to <%= next_version %>
+
+Via:
+
+```console
+$ rake <%= ns %>:<%= name %>'[<%= next_version %>]'
+```
+
+Read the [<%= release_label %>](<%= release_url %>) for details.
+MSG
+
+      attr_reader :ns
+      attr_accessor :files
+      attr_accessor :current_version
+      attr_accessor :commit_message_template
+
+      def initialize(name, ns, target_name)
+        super(name)
+
+        @ns = ns || default_namespace
+        @target_name = target_name
+        @files ||= []
+        @commit_message_template = DEFAULT_COMMIT_MESSAGE_TEMPLATE
+
+        yield self if block_given?
+
+        namespace(ns) { define }
+      end
+
+      def default_namespace
+        :bump
+      end
+
+      private
+
+      attr_reader :target_name
+      attr_accessor :next_version
+
+      def target_files
+        Set.new(files)
+      end
+
+      def define
+        desc "Bump #{target_name} version"
+        task name, [:next_version] do |_task, args|
+          self.next_version = args.fetch(:next_version) or raise "`next_version is required`"
+          current_version or raise "`current_version` is required"
+
+          puts "Bumping #{target_name} from #{current_version} to #{next_version} ..."
+          puts ""
+
+          current_version_pattern = Regexp.new('\b' + Regexp.escape(current_version) + '\b')
+
+          changed_files = target_files.each_with_object([]) do |file, new_files|
+            next unless File.exist? file
+
+            if dry_run?
+              puts "#{file} will be changed."
+            else
+              print "Writing #{file} ..."
+              content = File.read(file)
+              content.gsub!(current_version_pattern, next_version)
+              File.write(file, content)
+              puts " OK"
+              puts ""
+            end
+
+            new_files << file
+          end
+
+          if changed_files.empty?
+            puts "No changed files."
+          elsif !dry_run?
+            puts "Committing changed files ..."
+            puts ""
+            sh "git", "add", *changed_files
+            sh "git", "commit", "-m", commit_message
+          end
+        end
+
+        def commit_message
+          ERB.new(commit_message_template).result_with_hash(
+            ns: ns,
+            name: name,
+            target_name: target_name,
+            current_version: current_version,
+            next_version: next_version,
+            release_label: release_label,
+            release_url: release_url,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/aufgaben/bump/base.rb
+++ b/lib/aufgaben/bump/base.rb
@@ -87,18 +87,18 @@ MSG
             sh "git", "commit", "-m", commit_message
           end
         end
+      end
 
-        def commit_message
-          ERB.new(commit_message_template).result_with_hash(
-            ns: ns,
-            name: name,
-            target_name: target_name,
-            current_version: current_version,
-            next_version: next_version,
-            release_label: release_label,
-            release_url: release_url,
-          )
-        end
+      def commit_message
+        ERB.new(commit_message_template).result_with_hash(
+          ns: ns,
+          name: name,
+          target_name: target_name,
+          current_version: current_version,
+          next_version: next_version,
+          release_label: release_label,
+          release_url: release_url,
+        )
       end
     end
   end

--- a/lib/aufgaben/bump/nodejs.rb
+++ b/lib/aufgaben/bump/nodejs.rb
@@ -1,0 +1,50 @@
+require_relative "./base"
+
+module Aufgaben
+  class Bump::Nodejs < Bump::Base
+    DEFAULT_FILES = %w[
+      Dockerfile
+    ].freeze
+
+    DEFAULT_VERSION_FILES = %w[
+      .node-version
+      .nvmrc
+    ].freeze
+
+    attr_accessor :version_files
+
+    def initialize(name = :nodejs, ns = default_namespace)
+      self.files = DEFAULT_FILES.dup
+      self.version_files = DEFAULT_VERSION_FILES.dup
+
+      super(name, ns, "Node.js")
+    end
+
+    private
+
+    def current_version
+      @current_version ||= init_current_version
+    end
+
+    def init_current_version
+      version_files.each do |file|
+        next unless File.exist? file
+        match = File.read(file).match(/^(\d+\.\d+\.\d+)$/)
+        return match.captures[0] if match
+      end
+    end
+
+    def target_files
+      Set.new(files + version_files)
+    end
+
+    def release_label
+      "changelog"
+    end
+
+    def release_url
+      major_version = Integer(next_version.match(/^(\d+)\./).captures[0])
+      "https://github.com/nodejs/node/blob/v#{next_version}/doc/changelogs/CHANGELOG_V#{major_version}.md"
+    end
+  end
+end

--- a/lib/aufgaben/bump/ruby.rb
+++ b/lib/aufgaben/bump/ruby.rb
@@ -1,25 +1,11 @@
-require "erb"
-
-require_relative "../bump"
-require_relative "../base"
+require_relative "./base"
 
 module Aufgaben
-  class Bump::Ruby < Base
+  class Bump::Ruby < Bump::Base
     DEFAULT_FILES = %w[
       .ruby-version
       Dockerfile
     ].freeze
-
-    DEFAULT_COMMIT_MESSAGE_TEMPLATE = <<~'MSG'.freeze
-      Bump Ruby from <%= current_version %> to <%= next_version %>
-
-      Via:
-      ```
-      $ rake <%= ns %>:<%= name %>'[<%= next_version %>]'
-      ```
-
-      See <%= release_note_url %>
-    MSG
 
     DEFAULT_RELEASE_NOTE_URL = "https://www.ruby-lang.org/en/news".freeze
     RELEASE_NOTE_URLS = {
@@ -34,73 +20,21 @@ module Aufgaben
       "2.6.0": "https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/",
     }.freeze
 
-    attr_reader :name
-    attr_reader :ns
-    attr_accessor :files
-    attr_accessor :current_version
-    attr_accessor :commit_message_template
+    def initialize(name = :ruby, ns = default_namespace)
+      self.files = DEFAULT_FILES.dup
+      self.current_version = RUBY_VERSION
 
-    def initialize(name = :ruby, ns = :bump)
-      super(name)
-      @ns = ns
-      @files = DEFAULT_FILES.dup
-      @current_version = RUBY_VERSION
-      @commit_message_template = DEFAULT_COMMIT_MESSAGE_TEMPLATE
-
-      yield self if block_given?
-      namespace(ns) { define }
+      super(name, ns, "Ruby")
     end
 
     private
 
-    attr_reader :next_version
-
-    def define
-      desc "Bump Ruby version"
-      task name, [:next_version] do |_task, args|
-        @next_version = args.fetch(:next_version)
-
-        puts "Bumping Ruby from #{current_version} to #{next_version} ..."
-        puts ""
-
-        current_version_pattern = Regexp.new('\b' + Regexp.escape(current_version) + '\b')
-
-        changed_files = files.each_with_object([]) do |file, new_files|
-          next unless File.exist? file
-
-          if dry_run?
-            puts "#{file} will be changed."
-          else
-            print "Writing #{file} ..."
-            content = File.read(file)
-            content.gsub!(current_version_pattern, next_version)
-            File.write(file, content)
-            puts " OK"
-            puts ""
-          end
-
-          new_files << file
-        end
-
-        if changed_files.empty?
-          puts "No changed files."
-        elsif !dry_run?
-          puts "Committing changed files ..."
-          puts ""
-          sh "git", "add", *changed_files
-          sh "git", "commit", "-m", commit_message
-        end
-      end
+    def release_label
+      "release note"
     end
 
-    def commit_message
-      ERB.new(commit_message_template).result_with_hash(
-        ns: ns,
-        name: name,
-        current_version: current_version,
-        next_version: next_version,
-        release_note_url: RELEASE_NOTE_URLS.fetch(next_version.to_sym, DEFAULT_RELEASE_NOTE_URL)
-      )
+    def release_url
+      RELEASE_NOTE_URLS.fetch(next_version.to_sym, DEFAULT_RELEASE_NOTE_URL)
     end
   end
 end

--- a/test/aufgaben/bump/nodejs_test.rb
+++ b/test/aufgaben/bump/nodejs_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class BumpNodejsTest < Minitest::Test
+  include TestHelper
+
+  def run!(arg)
+    sh! "git init"
+    sh! "git add ."
+    sh! "git commit -m 'Init'"
+    sh! "rake bump:nodejs[#{arg}]"
+  end
+
+  def test_default
+    in_tmpdir do
+      File.write "Rakefile", <<~RUBY
+        require "aufgaben/bump/nodejs"
+        Aufgaben::Bump::Nodejs.new
+      RUBY
+      File.write ".node-version", "12.16.0\n"
+      File.write ".nvmrc", "12.16.0\n"
+      File.write "Dockerfile", <<~EOF
+        FROM node:12.16.0-buster-slim
+        RUN node -v
+      EOF
+
+      run! "12.16.1"
+
+      assert_equal "12.16.1\n", File.read(".node-version")
+      assert_equal "12.16.1\n", File.read(".nvmrc")
+      assert_equal <<~EOF, File.read("Dockerfile")
+        FROM node:12.16.1-buster-slim
+        RUN node -v
+      EOF
+
+      stdout, = sh! "git show --pretty=full"
+      assert_includes stdout, <<~MSG.gsub(/^/, "    ")
+        Bump Node.js from 12.16.0 to 12.16.1
+
+        Via:
+
+        ```console
+        $ rake bump:nodejs'[12.16.1]'
+        ```
+
+        Read the [changelog](https://github.com/nodejs/node/blob/v12.16.1/doc/changelogs/CHANGELOG_V12.md) for details.
+      MSG
+    end
+  end
+
+  def test_set_version_files
+    in_tmpdir do
+      File.write "Rakefile", <<~RUBY
+        require "aufgaben/bump/nodejs"
+        Aufgaben::Bump::Nodejs.new do |t|
+          t.version_files << "nodejs-version.txt"
+        end
+      RUBY
+      File.write "nodejs-version.txt", "12.16.0\n"
+      File.write "Dockerfile", <<~EOF
+        FROM node:12.16.0
+        RUN node -v
+      EOF
+
+      run! "12.16.1"
+
+      assert_equal "12.16.1\n", File.read("nodejs-version.txt")
+      assert_equal <<~EOF, File.read("Dockerfile")
+        FROM node:12.16.1
+        RUN node -v
+      EOF
+    end
+  end
+end

--- a/test/aufgaben/bump/ruby_test.rb
+++ b/test/aufgaben/bump/ruby_test.rb
@@ -22,9 +22,17 @@ class BumpRubyTest < Minitest::Test
       assert_equal "2.6.5\n", Pathname(".ruby-version").read
 
       stdout, = sh! "git show --pretty=full"
-      assert_match "Bump Ruby from 2.6.4 to 2.6.5", stdout
-      assert_match "$ rake bump:ruby'[2.6.5]'", stdout
-      assert_match "See https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/", stdout
+      assert_includes stdout, <<~MSG.gsub(/^/, "    ")
+        Bump Ruby from 2.6.4 to 2.6.5
+
+        Via:
+
+        ```console
+        $ rake bump:ruby'[2.6.5]'
+        ```
+
+        Read the [release note](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/) for details.
+      MSG
     end
   end
 


### PR DESCRIPTION
This change also adds a `Aufgaben::Bump::Base` class where the common bumping is written.

Example:

```ruby
require "aufgaben/bump/nodejs"
Aufgaben::Bump::Nodejs.new do |t|
  t.files << "Dockerfile.production" # defaults to ["Dockerfile"]
  t.version_files << "nodejs-version.txt" # defaults to [".node-version", ".nvmrc"]
end
```

- `.node-version` file is supported by [nodenv](https://github.com/nodenv/nodenv).
- `.nvmrc` file is supported by [nvm](https://github.com/nvm-sh/nvm).