### PR TITLE
Add Ruby 2.7 for `bump:ruby`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.5.0...HEAD)
 
+- Add Ruby 2.7 for `bump:ruby` [#25](https://github.com/ybiquitous/aufgaben/pull/25)
+
 ## 0.5.0
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.4.2...0.5.0)

--- a/lib/aufgaben/bump/ruby.rb
+++ b/lib/aufgaben/bump/ruby.rb
@@ -9,6 +9,7 @@ module Aufgaben
 
     DEFAULT_RELEASE_NOTE_URL = "https://www.ruby-lang.org/en/news".freeze
     RELEASE_NOTE_URLS = {
+      "2.7.2": "https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/",
       "2.7.1": "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/",
       "2.7.0": "https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/",
       "2.6.6": "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/",


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/