### PR TITLE
Remove extra commands on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: |
-          gem install bundler --no-document
-          bundle config set path vendor/bundle
-          bundle config set jobs 4
-          bundle config set retry 3
-          bundle install
+      - run: bundle install
       - run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"


### PR DESCRIPTION
The `ruby/setup-ruby` action runs these commands by default.