### PR TITLE
Add Ruby 3.0.0 for `bump:ruby`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.6.0...HEAD)
 
+- Add Ruby 3.0.0 for `bump:ruby` [#30](https://github.com/ybiquitous/aufgaben/pull/30)
+
 ## 0.6.0
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.5.1...0.6.0)

--- a/lib/aufgaben/bump/ruby.rb
+++ b/lib/aufgaben/bump/ruby.rb
@@ -9,6 +9,7 @@ module Aufgaben
 
     DEFAULT_RELEASE_NOTE_URL = "https://www.ruby-lang.org/en/news".freeze
     RELEASE_NOTE_URLS = {
+      "3.0.0": "https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/",
       "2.7.2": "https://www.ruby-lang.org/en/news/2020/10/02/ruby-2-7-2-released/",
       "2.7.1": "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/",
       "2.7.0": "https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/",


### PR DESCRIPTION
<https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/>