### PR TITLE
Release on GitHub Actions including `gem push`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
           bundler-cache: true
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+      - run: bundle exec rake 'release[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
       - run: git push --follow-tags
       - run: echo ::set-output name=tag::$(git describe --abbrev=0)
         id: tag
       - run: gh release create '${{ steps.tag.outputs.tag }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.tag }}/CHANGELOG.md) for details.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: bundle exec rake 'release[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
       - run: bundle exec gem build
       - run: bundle exec gem push *.gem --otp '${{ github.event.inputs.otp }}'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,33 @@
 name: Release
 
 on:
-  push:
-    tags: ["**"]
-
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New gem version"
+        required: true
+      otp:
+        description: "One time password for MFA"
+        required: true
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+          bundler-cache: true
+      - run: git config --global user.name '${{ github.actor }}'
+      - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+      - run: git push --follow-tags
+      - run: echo ::set-output name=tag::$(git describe --abbrev=0)
         id: tag
       - run: gh release create '${{ steps.tag.outputs.tag }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.tag }}/CHANGELOG.md) for details.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: bundle exec rake 'release[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
+      - run: bundle exec gem build
+      - run: bundle exec gem push *.gem --otp '${{ github.event.inputs.otp }}'
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           bundler-cache: true
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-      - run: bundle exec rake 'release[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
+      - run: bundle exec rake 'release_new[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
       - run: git push --follow-tags
       - run: echo ::set-output name=tag::$(git describe --abbrev=0)
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       otp:
         description: "One time password for MFA"
         required: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "New gem version"
+        description: "New gem version, e.g. `1.2.3`"
         required: true
       otp:
         description: "One time password for MFA"
@@ -23,12 +23,10 @@ jobs:
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
       - run: bundle exec rake 'release_new[${{ github.event.inputs.version }}]' NONINTERACTIVE=1
       - run: git push --follow-tags
-      - run: echo ::set-output name=tag::$(git describe --abbrev=0)
-        id: tag
-      - run: gh release create '${{ steps.tag.outputs.tag }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ steps.tag.outputs.tag }}/CHANGELOG.md) for details.'
+      - run: gh release create '${{ github.event.inputs.version }}' --notes 'See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.event.inputs.version }}/CHANGELOG.md) for details.'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bundle exec gem build
-      - run: bundle exec gem push *.gem --otp '${{ github.event.inputs.otp }}'
+      - run: bundle exec gem push --otp='${{ github.event.inputs.otp }}' 'aufgaben-${{ github.event.inputs.version }}.gem'
         env:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,3 @@ jobs:
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
       - run: bundle exec rake
-      - run: bundle exec rake 'release_new[99.99.99]' DRY_RUN=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,4 @@ jobs:
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
       - run: bundle exec rake
+      - run: bundle exec rake 'release_new[99.99.99]' DRY_RUN=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.0...HEAD)
 
+- Release on GitHub Actions including gem push [#41](https://github.com/ybiquitous/aufgaben/pull/41)
+
 ## 0.8.0
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.7.1...0.8.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.0...HEAD)
 
-- Release on GitHub Actions including gem push [#41](https://github.com/ybiquitous/aufgaben/pull/41)
+- This version is now available on RubyGems.org! [#41](https://github.com/ybiquitous/aufgaben/pull/41)
 
 ## 0.8.0
 


### PR DESCRIPTION
Note: It is necessary to add a secret for RubyGems.org API key.

See also:
- https://guides.rubygems.org/command-reference/#gem-build
- https://guides.rubygems.org/command-reference/#gem-push
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch