### PR TITLE
Retry releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.0...0.8.1)
 
-- This version is now available on RubyGems.org! [#41](https://github.com/ybiquitous/aufgaben/pull/41)
+- ~~This version is now available on RubyGems.org!~~ [#41](https://github.com/ybiquitous/aufgaben/pull/41)
+  → Failed.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-[Full diff](/0.8.1...HEAD)
+[Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.1...HEAD)
+
+- Retry releasing [#42](https://github.com/ybiquitous/aufgaben/pull/42)
 
 ## 0.8.1
 

--- a/lib/aufgaben/version.rb
+++ b/lib/aufgaben/version.rb
@@ -1,3 +1,3 @@
-0.8.1module0.8.1 0.8.1Aufgaben0.8.1
-  0.8.1VERSION0.8.1 = "0.8.100.8.1.0.8.180.8.1.0.8.100.8.1".0.8.1freeze0.8.1
-0.8.1end0.8.1
+module Aufgaben
+  VERSION = "0.8.1".freeze
+end


### PR DESCRIPTION
Follow-up of #41

`fetch-depth: 0` is necessary to fetch the Git all history.

See also:
- https://github.com/ybiquitous/aufgaben/runs/3025479934