### PR TITLE
Use GEM_HOST_OTP_CODE for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: bundle exec gem build
-      - run: bundle exec gem push --otp='${{ github.event.inputs.otp }}' 'aufgaben-${{ github.event.inputs.version }}.gem'
+      - run: bundle exec gem push 'aufgaben-${{ github.event.inputs.version }}.gem'
         env:
           GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+          GEM_HOST_OTP_CODE: ${{ github.event.inputs.otp }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,3 @@ jobs:
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
       - run: bundle exec rake
-      - run: gem -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,4 @@ jobs:
       - run: git config --global user.name '${{ github.actor }}'
       - run: git config --global user.email '${{ github.actor }}@users.noreply.github.com'
       - run: bundle exec rake
+      - run: gem -v


### PR DESCRIPTION
This change is just a refactoring.

The environment variable `GEM_HOST_OTP_CODE` is available since gem 3.22.2 (available on Actions!):
https://github.com/rubygems/rubygems/releases/tag/v3.2.22