### PR TITLE
Check if specified files are updated on `release` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.3...HEAD)
 
+- Check if specified files are updated on `release` task [#46](https://github.com/ybiquitous/aufgaben/pull/46)
+
 ## 0.8.3
 
 [Full diff](https://github.com/ybiquitous/aufgaben/compare/0.8.2...0.8.3)


### PR DESCRIPTION
This PR aims to let the `release` task fail in the following case:

---

Assuming the current version (== git tag) is `1.0.0`, then the version mismatches a version in the `version.rb` file.

```ruby
# Rakefile
Aufgaben::Release.new do |t|
  t.files = ["version.rb"]
end
```

```ruby
# version.rb
version = '0.0.1'
```

```console
$ bundle exec release'[1.1.0]'
...
The current version '1.0.0' is not found in 'version.rb'!
```