### PR TITLE
Refactor to use `git` helper method

### DIFF
--- a/lib/aufgaben/base.rb
+++ b/lib/aufgaben/base.rb
@@ -17,5 +17,9 @@ module Aufgaben
     def dry_run?
       ENV["DRY_RUN"] || dry_run
     end
+
+    def git(*cmd, &block)
+      sh("git", *cmd, &block)
+    end
   end
 end

--- a/lib/aufgaben/bump/base.rb
+++ b/lib/aufgaben/bump/base.rb
@@ -83,8 +83,8 @@ MSG
           elsif !dry_run?
             puts "Committing changed files ..."
             puts ""
-            sh "git", "add", *changed_files
-            sh "git", "commit", "-m", commit_message
+            git "add", *changed_files
+            git "commit", "-m", commit_message
           end
         end
       end

--- a/lib/aufgaben/release.rb
+++ b/lib/aufgaben/release.rb
@@ -34,8 +34,8 @@ module Aufgaben
 
         msg "If you want to do this on dry-run mode, set 'DRY_RUN=1'." unless dry_run?
 
-        sh "git", "checkout", default_branch, "--quiet"
-        sh "git", "pull", "origin", default_branch, "--quiet"
+        git "checkout", default_branch, "--quiet"
+        git "pull", "origin", default_branch, "--quiet"
         sh "bundle", "install", "--quiet"
 
         if current_version.empty?
@@ -47,7 +47,7 @@ module Aufgaben
           end
         end
 
-        sh "git", "diff", "--exit-code", "--quiet" do |ok|
+        git "diff", "--exit-code", "--quiet" do |ok|
           abort "Uncommitted changes found!" unless ok
         end
 
@@ -57,7 +57,7 @@ module Aufgaben
           msg "Releasing a new version: #{current_version} -> #{colored_new_version}"
         end
 
-        sh "git", "--no-pager", "log", "--format=%C(auto)%h %Creset%s", "#{current_version}..HEAD"
+        git "--no-pager", "log", "--format=%C(auto)%h %Creset%s", "#{current_version}..HEAD"
 
         each_file do |file|
           update_version_in file, write: false
@@ -75,16 +75,16 @@ module Aufgaben
           else
             add_changelog with: new_version
           end
-          sh "git", "add", changelog
+          git "add", changelog
 
           each_file do |file|
             update_version_in file
-            sh "git", "add", file
+            git "add", file
           end
 
-          sh "git", "commit", "--quiet", "--message", "Version #{new_version}"
-          sh "git", "tag", "--annotate", "--message", "Version #{new_version}", new_version
-          sh "git", "show", "--pretty"
+          git "commit", "--quiet", "--message", "Version #{new_version}"
+          git "tag", "--annotate", "--message", "Version #{new_version}", new_version
+          git "show", "--pretty"
 
           git_push = Color.new("git push --follow-tags").green
           msg "The tag '#{colored_new_version}' is added. Run '#{git_push}'."


### PR DESCRIPTION
This change adds the `Aufgaben::Base#git` method to make the code easier to read.
See <https://ruby-doc.org/stdlib-3.0.1/libdoc/rake/rdoc/FileUtils.html#sh-method>