### PR TITLE
Drop Ruby 2.6 support

### DIFF
--- a/aufgaben.gemspec
+++ b/aufgaben.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Aufgaben provides a collection of practical Rake tasks for automation."
   spec.homepage      = "https://github.com/ybiquitous/aufgaben"
 
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 2.6 is now EOL. See https://www.ruby-lang.org/en/downloads/branches/

Ref: #57